### PR TITLE
Add ProximityTriggers

### DIFF
--- a/Resources/Database/Updates/Update_2025_08_12_2222.sql
+++ b/Resources/Database/Updates/Update_2025_08_12_2222.sql
@@ -1,0 +1,21 @@
+DROP TABLE IF EXISTS public.proximity_triggers CASCADE;
+
+CREATE TABLE public.proximity_triggers
+(
+    id serial NOT NULL,
+    name text NOT NULL DEFAULT '',
+    flags smallint NOT NULL DEFAULT '0',
+    map_id smallint NOT NULL DEFAULT '0',
+    position_x real NOT NULL DEFAULT '0.0',
+    position_y real NOT NULL DEFAULT '0.0',
+    position_z real NOT NULL DEFAULT '0.0',
+    extents_x real NOT NULL DEFAULT '1.0',
+    extents_y real NOT NULL DEFAULT '1.0',
+    extents_z real NOT NULL DEFAULT '1.0',
+    PRIMARY KEY (id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.proximity_triggers
+    OWNER to postgres;

--- a/Source/Server-Common/Server-Common.lua
+++ b/Source/Server-Common/Server-Common.lua
@@ -1,4 +1,4 @@
-local mod = Solution.Util.CreateModuleTable("Server-Common", { "base", "fileformat", "input", "network", "gameplay", "luau-compiler", "luau-vm", "enkits", "refl-cpp", "utfcpp", "base64", "libpqxx" })
+local mod = Solution.Util.CreateModuleTable("Server-Common", { "base", "fileformat", "meta", "input", "network", "gameplay", "luau-compiler", "luau-vm", "enkits", "refl-cpp", "utfcpp", "base64", "libpqxx" })
 
 Solution.Util.CreateStaticLib(mod.Name, Solution.Projects.Current.BinDir, mod.Dependencies, function()
     local defines = { "_CRT_SECURE_NO_WARNINGS", "_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS", "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS" }

--- a/Source/Server-Common/Server-Common/Database/Definitions.h
+++ b/Source/Server-Common/Server-Common/Database/Definitions.h
@@ -4,6 +4,8 @@
 
 #include <Gameplay/GameDefine.h>
 
+#include <Meta/Generated/Game/ProximityTriggerEnum.h>
+
 #include <robinhood/robinhood.h>
 
 #include <entt/fwd.hpp>
@@ -288,6 +290,17 @@ namespace Database
         u16 slot = 0;
     };
 
+    struct ProximityTrigger
+    {
+    public:
+        u32 id = 0;
+        std::string name = "";
+        Generated::ProximityTriggerFlagEnum flags = Generated::ProximityTriggerFlagEnum::None;
+        u16 mapID = 0;
+        vec3 position = vec3(0.0f, 0.0f, 0.0f);
+        vec3 extents = vec3(1.0f, 1.0f, 1.0f);
+    };
+
     struct PermissionTables
     {
     public:
@@ -321,5 +334,12 @@ namespace Database
         robin_hood::unordered_map<u64, std::vector<u16>> charIDToPermissions;
         robin_hood::unordered_map<u64, std::vector<u16>> charIDToPermissionGroups;
         robin_hood::unordered_map<u64, std::vector<CharacterCurrency>> charIDToCurrency;
+    };
+
+    struct ProximityTriggersTables
+    {
+    public:
+        std::vector<ProximityTrigger> triggers;
+        robin_hood::unordered_map<u32, entt::entity> triggerIDToEntity;
     };
 }

--- a/Source/Server-Common/Server-Common/Database/Util/ProximityTriggerUtils.cpp
+++ b/Source/Server-Common/Server-Common/Database/Util/ProximityTriggerUtils.cpp
@@ -1,0 +1,113 @@
+#include "ProximityTriggerUtils.h"
+#include "Server-Common/Database/DBController.h"
+
+#include <Base/Util/DebugHandler.h>
+#include <Base/Util/StringUtils.h>
+
+#include <pqxx/nontransaction>
+
+namespace Database::Util::ProximityTrigger
+{
+    namespace Loading
+    {
+        void InitProximityTriggersTablesPreparedStatements(std::shared_ptr<DBConnection>& dbConnection)
+        {
+            NC_LOG_INFO("Loading Prepared Statements Proximity Triggers Tables...");
+
+            try
+            {
+                dbConnection->connection->prepare("ProximityTriggerCreate", "INSERT INTO public.proximity_triggers (name, flags, map_id, position_x, position_y, position_z, extents_x, extents_y, extents_z) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id");
+                dbConnection->connection->prepare("ProximityTriggerDelete", "DELETE FROM public.proximity_triggers WHERE id = $1");
+
+                NC_LOG_INFO("Loaded Prepared Statements Proximity Triggers Tables\n");
+            }
+            catch (const pqxx::sql_error& e)
+            {
+                NC_LOG_CRITICAL("{0}", e.what());
+                return;
+            }
+        }
+
+        void LoadProximityTriggersTables(std::shared_ptr<DBConnection>& dbConnection, Database::ProximityTriggersTables& proximityTriggersTables)
+        {
+            NC_LOG_INFO("-- Loading Proximity Triggers Tables --");
+
+            u64 totalRows = 0;
+            totalRows += LoadProximityTriggers(dbConnection, proximityTriggersTables);
+
+            NC_LOG_INFO("-- Loaded Proximity Triggers Tables ({0} rows) --\n", totalRows);
+        }
+
+        u64 LoadProximityTriggers(std::shared_ptr<DBConnection>& dbConnection, Database::ProximityTriggersTables& proximityTriggersTables)
+        {
+            NC_LOG_INFO("Loading Table 'proximity_triggers'");
+
+            pqxx::nontransaction nonTransaction = dbConnection->NewNonTransaction();
+
+            auto result = nonTransaction.exec("SELECT COUNT(*) FROM public.proximity_triggers");
+            u64 numRows = result[0][0].as<u64>();
+
+            proximityTriggersTables.triggers.clear();
+
+            if (numRows == 0)
+            {
+                NC_LOG_INFO("Skipped Table 'proximity_triggers'");
+                return 0;
+            }
+
+            proximityTriggersTables.triggers.reserve(numRows);
+
+            nonTransaction.for_stream("SELECT * FROM public.proximity_triggers", [&proximityTriggersTables](u32 id, const std::string& name, u16 flags, u16 mapID, f32 positionX, f32 positionY, f32 positionZ, f32 extentsX, f32 extentsY, f32 extentsZ)
+            {
+                Database::ProximityTrigger trigger = 
+                {
+                    .id = id,
+                    .name = name,
+                    .flags = static_cast<Generated::ProximityTriggerFlagEnum>(flags),
+                    .mapID = mapID,
+                    .position = vec3(positionX, positionY, positionZ),
+                    .extents = vec3(extentsX, extentsY, extentsZ)
+                };
+                proximityTriggersTables.triggers.push_back(trigger);
+            });
+
+            NC_LOG_INFO("Loaded Table 'proximity_triggers' ({0} Rows)", numRows);
+            return numRows;
+        }
+    }
+
+    bool ProximityTriggerCreate(pqxx::work& transaction, const std::string& name, u16 flags, u16 mapID, const vec3& position, const vec3& extents, u32& triggerID)
+    {
+        try
+        {
+            auto queryResult = transaction.exec(pqxx::prepped("ProximityTriggerCreate"), pqxx::params{ name, flags, mapID, position.x, position.y, position.z, extents.x, extents.y, extents.z });
+            if (queryResult.empty())
+                return false;
+
+            triggerID = queryResult[0][0].as<u32>();
+            return true;
+        }
+        catch (const pqxx::sql_error& e)
+        {
+            NC_LOG_WARNING("{0}", e.what());
+            return false;
+        }
+    }
+
+    bool ProximityTriggerDelete(pqxx::work& transaction, u32 triggerID)
+    {
+        try
+        {
+            auto queryResult = transaction.exec(pqxx::prepped("ProximityTriggerDelete"), pqxx::params{ triggerID });
+            if (queryResult.affected_rows() == 0)
+                return false;
+
+            return true;
+        }
+        catch (const pqxx::sql_error& e)
+        {
+            NC_LOG_WARNING("{0}", e.what());
+            return false;
+        }
+    }
+}

--- a/Source/Server-Common/Server-Common/Database/Util/ProximityTriggerUtils.h
+++ b/Source/Server-Common/Server-Common/Database/Util/ProximityTriggerUtils.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "Server-Common/Database/Definitions.h"
+
+#include <Base/Types.h>
+
+#include <pqxx/pqxx>
+
+namespace Database
+{
+    struct DBConnection;
+
+    namespace Util::ProximityTrigger
+    {
+        namespace Loading
+        {
+            void InitProximityTriggersTablesPreparedStatements(std::shared_ptr<DBConnection>& dbConnection);
+
+            void LoadProximityTriggersTables(std::shared_ptr<DBConnection>& dbConnection, Database::ProximityTriggersTables& proximityTriggersTables);
+            u64 LoadProximityTriggers(std::shared_ptr<DBConnection>& dbConnection, Database::ProximityTriggersTables& proximityTriggersTables);
+        }
+
+        bool ProximityTriggerCreate(pqxx::work& transaction, const std::string& name, u16 flags, u16 mapID, const vec3& position, const vec3& extents, u32& triggerID);
+        bool ProximityTriggerDelete(pqxx::work& transaction, u32 triggerID);
+    }
+}

--- a/Source/Server-Game/Server-Game/ECS/Components/AABB.h
+++ b/Source/Server-Game/Server-Game/ECS/Components/AABB.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <Base/Types.h>
+
+namespace ECS::Components
+{
+    struct AABB
+    {
+        vec3 centerPos;
+        vec3 extents;
+    };
+
+    struct WorldAABB
+    {
+        vec3 min;
+        vec3 max;
+    };
+}

--- a/Source/Server-Game/Server-Game/ECS/Components/ProximityTrigger.h
+++ b/Source/Server-Game/Server-Game/ECS/Components/ProximityTrigger.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <Base/Types.h>
+
+#include <Meta/Generated/Game/ProximityTriggerEnum.h>
+DECLARE_GENERIC_BITWISE_OPERATORS(Generated::ProximityTriggerFlagEnum);
+
+#include <entt/entt.hpp>
+#include <robinhood/robinhood.h>
+
+namespace ECS::Components
+{
+    struct ProximityTrigger
+    {
+    public:
+        u32 triggerID;
+        std::string name;
+        Generated::ProximityTriggerFlagEnum flags = Generated::ProximityTriggerFlagEnum::None;
+        robin_hood::unordered_set<entt::entity> playersInside; // Entities currently inside the trigger
+        robin_hood::unordered_set<entt::entity> playersEntered; // Entities that just entered
+        robin_hood::unordered_set<entt::entity> playersExited; // Entities that just entered
+    };
+}

--- a/Source/Server-Game/Server-Game/ECS/Components/Tags.h
+++ b/Source/Server-Game/Server-Game/ECS/Components/Tags.h
@@ -7,4 +7,8 @@ namespace ECS::Tags
     struct CharacterNeedsDeinitialization {};
     struct CharacterNeedsContainerUpdate {};
     struct CharacterNeedsDisplayUpdate {};
+    
+    struct ProximityTriggerNeedsInitialization {};
+    struct ProximityTriggerIsServerSideOnly {};
+    struct ProximityTriggerIsClientSide {};
 }

--- a/Source/Server-Game/Server-Game/ECS/Scheduler.cpp
+++ b/Source/Server-Game/Server-Game/ECS/Scheduler.cpp
@@ -6,6 +6,7 @@
 #include "Server-Game/ECS/Systems/CharacterUpdate.h"
 #include "Server-Game/ECS/Systems/DatabaseSetup.h"
 #include "Server-Game/ECS/Systems/NetworkConnection.h"
+#include "Server-Game/ECS/Systems/ProximityTrigger.h"
 #include "Server-Game/ECS/Systems/Replication.h"
 #include "Server-Game/ECS/Systems/UpdatePower.h"
 #include "Server-Game/ECS/Systems/UpdateScripts.h"
@@ -30,6 +31,7 @@ namespace ECS
         Systems::CharacterLoginHandler::Init(registry);
         Systems::CharacterInitialization::Init(registry);
         Systems::CharacterUpdate::Init(registry);
+        Systems::ProximityTrigger::Init(registry);
         Systems::UpdatePower::Init(registry);
         Systems::UpdateSpell::Init(registry);
         Systems::UpdateScripts::Init(registry);
@@ -43,6 +45,7 @@ namespace ECS
         Systems::CharacterLoginHandler::Update(registry, deltaTime);
         Systems::CharacterInitialization::Update(registry, deltaTime);
         Systems::CharacterUpdate::Update(registry, deltaTime);
+        Systems::ProximityTrigger::Update(registry, deltaTime);
         Systems::UpdatePower::Update(registry, deltaTime);
         Systems::UpdateSpell::Update(registry, deltaTime);
         Systems::Replication::Update(registry, deltaTime);

--- a/Source/Server-Game/Server-Game/ECS/Singletons/GameCache.h
+++ b/Source/Server-Game/Server-Game/ECS/Singletons/GameCache.h
@@ -25,6 +25,7 @@ namespace ECS
             Database::CurrencyTables currencyTables;
             Database::ItemTables itemTables;
             Database::CharacterTables characterTables;
+            Database::ProximityTriggersTables proximityTriggerTables;
         };
     }
 

--- a/Source/Server-Game/Server-Game/ECS/Singletons/ProximityTriggers.h
+++ b/Source/Server-Game/Server-Game/ECS/Singletons/ProximityTriggers.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <Base/Types.h>
+
+#include <entt/entt.hpp>
+#include <robinhood/robinhood.h>
+#include <RTree/RTree.h>
+
+namespace ECS
+{
+    namespace Singletons
+    {
+        struct ProximityTriggers
+        {
+        public:
+            robin_hood::unordered_map<u32, entt::entity> triggerIDToEntity;
+            robin_hood::unordered_set<u32> triggerIDsToDestroy;
+
+            robin_hood::unordered_set<u32> activeTriggers;
+            RTree<u32, f32, 3> activeTriggersVisTree;
+        };
+    }
+}

--- a/Source/Server-Game/Server-Game/ECS/Systems/DatabaseSetup.cpp
+++ b/Source/Server-Game/Server-Game/ECS/Systems/DatabaseSetup.cpp
@@ -8,6 +8,7 @@
 #include <Server-Common/Database/Util/CurrencyUtils.h>
 #include <Server-Common/Database/Util/ItemUtils.h>
 #include <Server-Common/Database/Util/PermissionUtils.h>
+#include <Server-Common/Database/Util/ProximityTriggerUtils.h>
 
 #include <Base/Util/DebugHandler.h>
 #include <Base/Util/JsonUtils.h>
@@ -70,11 +71,13 @@ namespace ECS::Systems
             Database::Util::Currency::InitCurrencyTablesPreparedStatements(characterConnection);
             Database::Util::Item::Loading::InitItemTablesPreparedStatements(characterConnection);
             Database::Util::Character::Loading::InitCharacterTablesPreparedStatements(characterConnection);
+            Database::Util::ProximityTrigger::Loading::InitProximityTriggersTablesPreparedStatements(characterConnection);
 
             Database::Util::Permission::LoadPermissionTables(characterConnection, gameCache.permissionTables);
             Database::Util::Currency::LoadCurrencyTables(characterConnection, gameCache.currencyTables);
             Database::Util::Item::Loading::LoadItemTables(characterConnection, gameCache.itemTables);
             Database::Util::Character::Loading::LoadCharacterTables(characterConnection, gameCache.characterTables, gameCache.itemTables);
+            Database::Util::ProximityTrigger::Loading::LoadProximityTriggersTables(characterConnection, gameCache.proximityTriggerTables);
         }
     }
 

--- a/Source/Server-Game/Server-Game/ECS/Systems/ProximityTrigger.cpp
+++ b/Source/Server-Game/Server-Game/ECS/Systems/ProximityTrigger.cpp
@@ -1,0 +1,240 @@
+#include "ProximityTrigger.h"
+
+#include "Server-Game/ECS/Components/AABB.h"
+#include "Server-Game/ECS/Components/CastInfo.h"
+#include "Server-Game/ECS/Components/ProximityTrigger.h"
+#include "Server-Game/ECS/Components/Tags.h"
+#include "Server-Game/ECS/Components/Transform.h"
+#include "Server-Game/ECS/Singletons/GameCache.h"
+#include "Server-Game/ECS/Singletons/NetworkState.h"
+#include "Server-Game/ECS/Singletons/ProximityTriggers.h"
+#include "Server-Game/ECS/Singletons/WorldState.h"
+#include "Server-Game/ECS/Util/CollisionUtil.h"
+#include "Server-Game/ECS/Util/GridUtil.h"
+#include "Server-Game/ECS/Util/MessageBuilderUtil.h"
+#include "Server-Game/ECS/Util/Network/NetworkUtil.h"
+#include "Server-Game/Util/ServiceLocator.h"
+
+#include <Base/Util/DebugHandler.h>
+
+#include <Network/Server.h>
+
+#include <entt/entt.hpp>
+#include <tracy/Tracy.hpp>
+
+namespace ECS::Systems
+{
+    void ProximityTrigger::Init(entt::registry& registry)
+    {
+        auto& ctx = registry.ctx();
+
+        auto& gameCache = ctx.get<Singletons::GameCache>();
+        auto& proximityTriggers = ctx.emplace<Singletons::ProximityTriggers>();
+
+        for(const auto& trigger : gameCache.proximityTriggerTables.triggers)
+        {
+            entt::entity triggerEntity = registry.create();
+
+            auto& transform = registry.emplace<Components::Transform>(triggerEntity);
+            transform.mapID = trigger.mapID;
+            transform.position = trigger.position;
+
+            registry.emplace<Components::AABB>(triggerEntity, vec3(0, 0, 0), trigger.extents);
+            auto& proximityTrigger = registry.emplace<Components::ProximityTrigger>(triggerEntity);
+            proximityTrigger.triggerID = trigger.id;
+            proximityTrigger.name = trigger.name;
+            proximityTrigger.flags = trigger.flags;
+            registry.emplace<Tags::ProximityTriggerNeedsInitialization>(triggerEntity);
+
+            gameCache.proximityTriggerTables.triggerIDToEntity[trigger.id] = triggerEntity;
+        }
+    }
+
+    void OnEnter(Components::ProximityTrigger& trigger, entt::entity playerEntity)
+    {
+        NC_LOG_INFO("Trigger '{}' entered!", trigger.name);
+    }
+
+    void OnExit(Components::ProximityTrigger& trigger, entt::entity playerEntity)
+    {
+        NC_LOG_INFO("Trigger '{}' exited!", trigger.name);
+    }
+
+    void OnStay(Components::ProximityTrigger& trigger, entt::entity playerEntity)
+    {
+        NC_LOG_INFO("Trigger '{}' stayed!", trigger.name);
+    }
+
+    void ProximityTrigger::Update(entt::registry& registry, f32 deltaTime)
+    {
+        ZoneScopedN("ECS::ProximityTriggers");
+
+        auto& ctx = registry.ctx();
+        
+        auto& gameCache = ctx.get<Singletons::GameCache>();
+        auto& networkState = ctx.get<Singletons::NetworkState>();
+        auto& proximityTriggers = ctx.get<Singletons::ProximityTriggers>();
+        auto& worldState = ctx.get<Singletons::WorldState>();
+
+        // Initialize any new triggers that need to be created
+        auto proximityTriggerNeedsinitializationView = registry.view<Components::Transform, Components::AABB, Components::ProximityTrigger, Tags::ProximityTriggerNeedsInitialization>();
+        proximityTriggerNeedsinitializationView.each([&registry, &worldState, &networkState, &proximityTriggers](entt::entity entity, Components::Transform& transform, Components::AABB& aabb, Components::ProximityTrigger& trigger)
+        {
+            World& world = worldState.GetWorld(transform.mapID);
+
+            bool isServerSideOnly = (trigger.flags & Generated::ProximityTriggerFlagEnum::IsServerSideOnly) != Generated::ProximityTriggerFlagEnum::None;
+
+            if (isServerSideOnly)
+            {
+                registry.emplace<Tags::ProximityTriggerIsServerSideOnly>(entity);
+
+                // Calculate world AABB
+                Components::WorldAABB worldAABB;
+                worldAABB.min = transform.position + aabb.centerPos - aabb.extents;
+                worldAABB.max = transform.position + aabb.centerPos + aabb.extents;
+
+                // Add server side only triggers to the activeTriggers R-tree
+                proximityTriggers.activeTriggersVisTree.Insert(reinterpret_cast<f32*>(&worldAABB.min), reinterpret_cast<f32*>(&worldAABB.max), trigger.triggerID);
+                proximityTriggers.activeTriggers.insert(trigger.triggerID);
+            }
+            else
+            {
+                registry.emplace<Tags::ProximityTriggerIsClientSide>(entity);
+
+                // Replicate to the clients if this is a client side trigger
+                std::shared_ptr<Bytebuffer> triggerCreateMessage = Bytebuffer::Borrow<64>();
+                if (!Util::MessageBuilder::ProximityTrigger::BuildProximityTriggerCreate(triggerCreateMessage, trigger.triggerID, trigger.name, trigger.flags, transform.mapID, transform.position, aabb.extents))
+                    return;
+
+                world.GetPlayersInRadius(transform.position.x, transform.position.z, 100000.0f, [&](const GameDefine::ObjectGuid& guid) -> bool
+                {
+                    entt::entity playerEntity = world.GetEntity(guid);
+
+                    Network::SocketID socketID;
+                    if (!Util::Network::GetSocketIDFromCharacterID(networkState, guid.GetCounter(), socketID))
+                        return true;
+
+                    networkState.server->SendPacket(socketID, triggerCreateMessage);
+                    return true;
+                });
+            }
+        });
+        registry.clear<Tags::ProximityTriggerNeedsInitialization>();
+
+        // Destroy any triggers that need to be removed
+        for(auto triggerID : proximityTriggers.triggerIDsToDestroy)
+        {
+            if (!gameCache.proximityTriggerTables.triggerIDToEntity.contains(triggerID))
+                continue;
+
+            entt::entity triggerEntity = gameCache.proximityTriggerTables.triggerIDToEntity[triggerID];
+
+            auto& transform = registry.get<Components::Transform>(triggerEntity);
+            World& world = worldState.GetWorld(transform.mapID);
+
+            std::shared_ptr<Bytebuffer> triggerDestroyMessage = Bytebuffer::Borrow<32>();
+            if (!Util::MessageBuilder::ProximityTrigger::BuildProximityTriggerDelete(triggerDestroyMessage, triggerID))
+                continue;
+
+            gameCache.proximityTriggerTables.triggerIDToEntity.erase(triggerID);
+            proximityTriggers.activeTriggers.erase(triggerID);
+
+            auto& proximityTrigger = registry.get<Components::ProximityTrigger>(triggerEntity);
+            bool isServerSideOnly = (proximityTrigger.flags & Generated::ProximityTriggerFlagEnum::IsServerSideOnly) == Generated::ProximityTriggerFlagEnum::IsServerSideOnly;
+
+            world.GetPlayersInRadius(transform.position.x, transform.position.z, 100000.0f, [&](const GameDefine::ObjectGuid& guid) -> bool
+            {
+                entt::entity playerEntity = world.GetEntity(guid);
+
+                if (isServerSideOnly && proximityTrigger.playersInside.contains(playerEntity))
+                {
+                    OnExit(proximityTrigger, playerEntity);
+                }
+
+                Network::SocketID socketID;
+                if (!Util::Network::GetSocketIDFromCharacterID(networkState, guid.GetCounter(), socketID))
+                    return true;
+
+                networkState.server->SendPacket(socketID, triggerDestroyMessage);
+                return true;
+            });
+
+            registry.destroy(triggerEntity);
+        }
+        proximityTriggers.triggerIDsToDestroy.clear();
+
+        // Call client side trigger events
+        // For these we only care about OnEnter
+        auto clientSideTriggerView = registry.view<Components::Transform, Components::AABB, Components::ProximityTrigger, Tags::ProximityTriggerIsClientSide>();
+        clientSideTriggerView.each([&registry, &worldState](entt::entity triggerEntity, Components::Transform& triggerTransform, Components::AABB& triggerAABB, Components::ProximityTrigger& trigger)
+        {
+            // Loop over players that just entered the trigger and call OnEnter
+            for(auto playerEntity : trigger.playersEntered)
+            {
+                if (!registry.valid(playerEntity))
+                    continue;
+                OnEnter(trigger, playerEntity);
+                trigger.playersInside.insert(playerEntity);
+            }
+            trigger.playersEntered.clear();
+        });
+
+        // Call server side trigger events
+        robin_hood::unordered_set<entt::entity> playersToRemove;
+        playersToRemove.reserve(1024);
+
+        for (u32 triggerID : proximityTriggers.activeTriggers)
+        {
+            entt::entity triggerEntity = gameCache.proximityTriggerTables.triggerIDToEntity[triggerID];
+            if (!registry.valid(triggerEntity))
+                continue;
+
+            auto& triggerTransform = registry.get<Components::Transform>(triggerEntity);
+            auto& triggerAABB = registry.get<Components::AABB>(triggerEntity);
+            auto& proximityTrigger = registry.get<Components::ProximityTrigger>(triggerEntity);
+
+            World& world = worldState.GetWorld(triggerTransform.mapID);
+
+            vec4 minMaxRect = vec4(
+                triggerTransform.position.x + triggerAABB.centerPos.x - triggerAABB.extents.x,
+                triggerTransform.position.z + triggerAABB.centerPos.z - triggerAABB.extents.z,
+                triggerTransform.position.x + triggerAABB.centerPos.x + triggerAABB.extents.x,
+                triggerTransform.position.z + triggerAABB.centerPos.z + triggerAABB.extents.z
+            );
+
+            playersToRemove = proximityTrigger.playersInside;
+
+            world.GetPlayersInRect(minMaxRect, [&](const GameDefine::ObjectGuid& guid) -> bool
+            {
+                entt::entity playerEntity = world.GetEntity(guid);
+
+                Network::SocketID socketID;
+                if (!Util::Network::GetSocketIDFromCharacterID(networkState, guid.GetCounter(), socketID))
+                    return true;
+
+                if (proximityTrigger.playersInside.contains(playerEntity))
+                {
+                    OnStay(proximityTrigger, playerEntity);
+                    playersToRemove.erase(playerEntity);
+                }
+                else
+                {
+                    OnEnter(proximityTrigger, playerEntity);
+                    proximityTrigger.playersInside.insert(playerEntity);
+                }
+
+                return true;
+            });
+
+            // Loop over players that have exited the trigger and call OnExit
+            for (auto playerEntity : playersToRemove)
+            {
+                if (!registry.valid(playerEntity))
+                    continue;
+
+                OnExit(proximityTrigger, playerEntity);
+                proximityTrigger.playersInside.erase(playerEntity);
+            }
+        }
+    }
+}

--- a/Source/Server-Game/Server-Game/ECS/Systems/ProximityTrigger.h
+++ b/Source/Server-Game/Server-Game/ECS/Systems/ProximityTrigger.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <Base/Types.h>
+#include <entt/fwd.hpp>
+
+namespace ECS::Systems
+{
+    class ProximityTrigger
+    {
+    public:
+        static void Init(entt::registry& registry);
+        static void Update(entt::registry& registry, f32 deltaTime);
+    };
+}

--- a/Source/Server-Game/Server-Game/ECS/Util/CollisionUtil.cpp
+++ b/Source/Server-Game/Server-Game/ECS/Util/CollisionUtil.cpp
@@ -1,0 +1,57 @@
+#include "CollisionUtil.h"
+
+#include "Server-Game/ECS/Components/AABB.h"
+#include "Server-Game/ECS/Components/Transform.h"
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+namespace ECS::Util::Collision
+{
+    // Convert a local-space AABB under TRS to a world-space (min,max) AABB.
+    // Uses worldHalf = |R*S| * localHalf
+    inline void LocalAABBToWorldAABB(const Components::Transform& t, const Components::AABB& local, vec3& outMin, vec3& outMax)
+    {
+        const quat q = glm::normalize(t.rotation);
+        const mat3x3 R = glm::mat3_cast(q);
+
+        // Guard against degenerate scale to avoid infinities on crazy pipelines
+        const vec3 s = glm::max(t.scale, glm::vec3(1e-6f));
+        const mat3x3 S = glm::mat3(glm::vec3(s.x, 0, 0), vec3(0, s.y, 0), vec3(0, 0, s.z));
+        const mat3x3 M = R * S;
+
+        const vec3 worldCenter = t.position + M * local.centerPos;
+
+        // |M| as "componentwise abs on columns"
+        const mat3x3 A = mat3x3(glm::abs(M[0]), glm::abs(M[1]), glm::abs(M[2]));
+        const vec3 worldHalf = A * local.extents;
+
+        outMin = worldCenter - worldHalf;
+        outMax = worldCenter + worldHalf;
+    }
+
+    // Point-in-AABB
+    bool IsInside(const Components::Transform& pointTransform, const Components::Transform& boxTransform, const Components::AABB& boxLocalAABB)
+    {
+        vec3 minW, maxW;
+        LocalAABBToWorldAABB(boxTransform, boxLocalAABB, minW, maxW);
+
+        const vec3 p = pointTransform.position;
+        return (p.x >= minW.x && p.x <= maxW.x) &&
+            (p.y >= minW.y && p.y <= maxW.y) &&
+            (p.z >= minW.z && p.z <= maxW.z);
+    }
+
+    // AABB-vs-AABB overlap (both AABBs defined in their own local spaces)
+    bool Overlaps(const Components::Transform& aT, const Components::AABB& aLocal, const Components::Transform& bT, const Components::AABB& bLocal)
+    {
+        vec3 aMin, aMax, bMin, bMax;
+        LocalAABBToWorldAABB(aT, aLocal, aMin, aMax);
+        LocalAABBToWorldAABB(bT, bLocal, bMin, bMax);
+
+        return (aMin.x <= bMax.x && aMax.x >= bMin.x) &&
+            (aMin.y <= bMax.y && aMax.y >= bMin.y) &&
+            (aMin.z <= bMax.z && aMax.z >= bMin.z);
+    }
+}

--- a/Source/Server-Game/Server-Game/ECS/Util/CollisionUtil.h
+++ b/Source/Server-Game/Server-Game/ECS/Util/CollisionUtil.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <Base/Types.h>
+
+namespace ECS
+{
+    namespace Components
+    {
+        struct Transform;
+        struct AABB;
+    }
+}
+
+namespace ECS::Util::Collision
+{
+    bool IsInside(const Components::Transform& pointTransform, const Components::Transform& boxTransform, const Components::AABB& boxLocalAABB);
+    bool Overlaps(const Components::Transform& aT, const Components::AABB& aLocal, const Components::Transform& bT, const Components::AABB& bLocal);
+}

--- a/Source/Server-Game/Server-Game/ECS/Util/MessageBuilderUtil.cpp
+++ b/Source/Server-Game/Server-Game/ECS/Util/MessageBuilderUtil.cpp
@@ -368,6 +368,34 @@ namespace ECS::Util::MessageBuilder
         }
     }
 
+    namespace ProximityTrigger
+    {
+        bool BuildProximityTriggerCreate(std::shared_ptr<Bytebuffer>& buffer, u32 triggerID, const std::string& name, Generated::ProximityTriggerFlagEnum flags, u16 mapID, const vec3& position, const vec3& extents)
+        {
+            bool result = CreatePacket(buffer, Network::GameOpcode::Server_TriggerCreate, [&, triggerID, mapID]()
+            {
+                buffer->PutU32(triggerID);
+                buffer->PutString(name);
+                buffer->Put(flags);
+                buffer->PutU16(mapID);
+                buffer->Put(position);
+                buffer->Put(extents);
+            });
+
+            return result;
+        }
+
+        bool BuildProximityTriggerDelete(std::shared_ptr<Bytebuffer>& buffer, u32 triggerID)
+        {
+            bool result = CreatePacket(buffer, Network::GameOpcode::Server_TriggerDestroy, [&buffer, triggerID]()
+            {
+                buffer->PutU32(triggerID);
+            });
+
+            return result;
+        }
+    }
+
     namespace Cheat
     {
         bool BuildCheatCommandResultMessage(std::shared_ptr<Bytebuffer>& buffer, u8 result, const std::string& response)

--- a/Source/Server-Game/Server-Game/ECS/Util/MessageBuilderUtil.h
+++ b/Source/Server-Game/Server-Game/ECS/Util/MessageBuilderUtil.h
@@ -7,9 +7,11 @@
 #include <Base/Types.h>
 #include <Base/Memory/Bytebuffer.h>
 
-#include "Gameplay/GameDefine.h"
-#include "Gameplay/Network/Define.h"
-#include "Gameplay/Network/Opcode.h"
+#include <Gameplay/GameDefine.h>
+#include <Gameplay/Network/Define.h>
+#include <Gameplay/Network/Opcode.h>
+
+#include <Meta/Generated/Game/ProximityTriggerEnum.h>
 
 #include <entt/fwd.hpp>
 
@@ -82,6 +84,12 @@ namespace ECS
             bool BuildDamageDealtMessage(std::shared_ptr<Bytebuffer>& buffer, GameDefine::ObjectGuid sourceGuid, GameDefine::ObjectGuid targetGuid, f32 damage);
             bool BuildHealingDoneMessage(std::shared_ptr<Bytebuffer>& buffer, GameDefine::ObjectGuid sourceGuid, GameDefine::ObjectGuid targetGuid, f32 healing);
             bool BuildRessurectedMessage(std::shared_ptr<Bytebuffer>& buffer, GameDefine::ObjectGuid sourceGuid, GameDefine::ObjectGuid targetGuid);
+        }
+
+        namespace ProximityTrigger
+        {
+            bool BuildProximityTriggerCreate(std::shared_ptr<Bytebuffer>& buffer, u32 triggerID, const std::string& name, Generated::ProximityTriggerFlagEnum flags, u16 mapID, const vec3& position, const vec3& extents);
+            bool BuildProximityTriggerDelete(std::shared_ptr<Bytebuffer>& buffer, u32 triggerID);
         }
 
         namespace Cheat

--- a/Source/Server-Game/Server-Game/ECS/Util/ProximityTriggerUtil.cpp
+++ b/Source/Server-Game/Server-Game/ECS/Util/ProximityTriggerUtil.cpp
@@ -1,0 +1,23 @@
+#include "ProximityTriggerUtil.h"
+
+#include "Server-Game/ECS/Components/ProximityTrigger.h"
+#include "Server-Game/ECS/Components/Tags.h"
+
+namespace ECS::Util::ProximityTrigger
+{
+    bool AddPlayerToTrigger(entt::registry& registry, entt::entity triggerEntity, entt::entity playerEntity)
+    {
+        auto& ProximityTrigger = registry.get<Components::ProximityTrigger>(triggerEntity);
+        ProximityTrigger.playersEntered.insert(playerEntity);
+
+        return true;
+    }
+
+    bool RemovePlayerFromTrigger(entt::registry& registry, entt::entity triggerEntity, entt::entity playerEntity)
+    {
+        auto& ProximityTrigger = registry.get<Components::ProximityTrigger>(triggerEntity);
+        ProximityTrigger.playersExited.insert(playerEntity);
+
+        return true;
+    }
+}

--- a/Source/Server-Game/Server-Game/ECS/Util/ProximityTriggerUtil.h
+++ b/Source/Server-Game/Server-Game/ECS/Util/ProximityTriggerUtil.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <Base/Types.h>
+
+#include <entt/fwd.hpp>
+
+namespace ECS
+{
+    namespace Components
+    {
+        struct Transform;
+        struct AABB;
+    }
+}
+
+namespace ECS::Util::ProximityTrigger
+{
+    bool AddPlayerToTrigger(entt::registry& registry, entt::entity triggerEntity, entt::entity playerEntity);
+    bool RemovePlayerFromTrigger(entt::registry& registry, entt::entity triggerEntity, entt::entity playerEntity);
+}


### PR DESCRIPTION
Added support for ProximityTriggers with OnEnter, OnExit and OnStay functions Triggers can be ServerSideOnly, ServerAuthorative (OnEnter command gets sent) or completely clientside Triggers get replicated from the server to the client Added AABB and WorldAABB components
Added cheat commands to Add and Remove triggers
Added CollisionUtil with the IsInside and Overlaps functions I needed Updated Engine submodule